### PR TITLE
Chrome WebDriver find element bug fix 

### DIFF
--- a/pytrunk.py
+++ b/pytrunk.py
@@ -97,7 +97,7 @@ def follow_tooters():
       target = f'{setup["home_domain"]}/authorize_interaction?uri={uri}'
       driver.get(target)
       try:
-        submit = driver.find_element_by_xpath('/html/body/div[2]/div/form/button')
+        submit = driver.find_element("xpath", '/html/body/div[2]/div/form/button')
         print(f"""
 {name}
 {v['lists']}

--- a/pytrunk.py
+++ b/pytrunk.py
@@ -99,10 +99,9 @@ def follow_tooters():
       try:
         submit = driver.find_element("xpath", '/html/body/div[2]/div/form/button')
         print(f"""
-{name}
-{v['lists']}
-{v['last_post']}
-""")
+          {name}
+          {v['lists']}
+          """)
         follow = input('follow? (press y for yes)')
         if follow=='y':
           submit.click()

--- a/pytrunk.py
+++ b/pytrunk.py
@@ -101,13 +101,14 @@ def follow_tooters():
         print(f"""
           {name}
           {v['lists']}
+          {v['last_post'] if 'last_post' in v else None}
           """)
         follow = input('follow? (press y for yes)')
         if follow=='y':
           submit.click()
       except:
         pass
-    
+
 if __name__ == '__main__':
   if len(sys.argv)!=2:
     print('1 parameter only. options: save_lists, find_tooters, follow_tooters')


### PR DESCRIPTION
## Issue at hand
- Chrome web driver removed support for `find_element_by_xpath()`

## Explanation of solution
- replaced driver function used with new `find_element("xpath", ...)`
- Small fixes: Clean up indentation of `printf` lines & removes `last_post` from printed output as it doesn't exist for all tooters data